### PR TITLE
Enable autocomplete script for admin forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# price_table_new
+# WP Price Manager
+
+WP Price Manager is a WordPress plugin for managing service prices and displaying them with an Elementor widget. It lets you create categories of services, associate them with price groups, and edit everything in a user friendly interface.
+
+## Installation
+
+1. Copy the `WP Price Manager` folder to your `wp-content/plugins` directory.
+2. Activate **WP Price Manager** in the WordPress admin panel.
+3. Make sure Elementor 3.5+ is installed and active to use the widget.
+
+## Usage
+
+After activation new menu items appear under **Price Manager**:
+
+- **Категории** – create and sort service categories with drag-and-drop and quickly add services within a category.
+- **Все услуги** – add and search services. The form provides autocomplete for categories and price groups.
+- **Группа цен** – manage price groups. Editing a group prompts for confirmation before bulk price updates.
+
+### Elementor Widget
+
+In the Elementor editor search for **Price List**. Drop the widget onto the page and select a service category in the **Content** tab. Style the table in the **Style** tab (colors, borders, alignment, etc.). Each row displays an info icon; hover or tap it to view the service description.
+

--- a/WP Price Manager/admin/class-price-manager-admin.php
+++ b/WP Price Manager/admin/class-price-manager-admin.php
@@ -96,16 +96,18 @@ class Price_Manager_Admin {
             <table class="wp-list-table widefat fixed striped">
                 <thead>
                     <tr>
+                        <th></th>
                         <th><?php _e( 'ID', 'wp-price-manager' ); ?></th>
                         <th><?php _e( 'Название', 'wp-price-manager' ); ?></th>
                         <th><?php _e( 'Порядок', 'wp-price-manager' ); ?></th>
                         <th><?php _e( 'Действия', 'wp-price-manager' ); ?></th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="wppm-categories-list">
                     <?php if ( $categories ) : ?>
                         <?php foreach ( $categories as $cat ) : ?>
-                            <tr>
+                            <tr id="<?php echo intval( $cat['id'] ); ?>">
+                                <td class="wppm-drag-handle" style="cursor: move;">⇅</td>
                                 <td><?php echo esc_html( $cat['id'] ); ?></td>
                                 <td><?php echo esc_html( $cat['name'] ); ?></td>
                                 <td><?php echo esc_html( $cat['display_order'] ); ?></td>
@@ -119,7 +121,7 @@ class Price_Manager_Admin {
                         <?php endforeach; ?>
                     <?php else : ?>
                         <tr>
-                            <td colspan="4"><?php _e( 'Категории не найдены', 'wp-price-manager' ); ?></td>
+                            <td colspan="5"><?php _e( 'Категории не найдены', 'wp-price-manager' ); ?></td>
                         </tr>
                     <?php endif; ?>
                 </tbody>
@@ -153,7 +155,7 @@ class Price_Manager_Admin {
     <div class="wrap">
         <h1><?php _e( 'Все услуги', 'wp-price-manager' ); ?></h1>
         <h2><?php _e( 'Добавить новую услугу', 'wp-price-manager' ); ?></h2>
-        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+        <form id="wppm-add-service-form" method="post" action="">
             <input type="hidden" name="action" value="wppm_add_service">
             <?php wp_nonce_field( 'wppm_service_nonce', 'wppm_service_nonce_field' ); ?>
             <table class="form-table">
@@ -188,15 +190,7 @@ class Price_Manager_Admin {
                                 echo '<input type="text" value="' . esc_attr($cat->name) . '" disabled>';
                             }
                         } else {
-                            $categories = $wpdb->get_results( "SELECT * FROM $cat_table ORDER BY display_order ASC", ARRAY_A );
-                            echo '<select name="service_category_id" required>';
-                            echo '<option value="">' . __( 'Выберите категорию', 'wp-price-manager' ) . '</option>';
-                            if ( $categories ) {
-                                foreach ( $categories as $cat_item ) {
-                                    echo '<option value="' . intval($cat_item['id']) . '">' . esc_html($cat_item['name']) . '</option>';
-                                }
-                            }
-                            echo '</select>';
+                            echo '<input type="text" id="service_category" name="service_category" required>';
                         }
                         ?>
                     </td>
@@ -206,6 +200,15 @@ class Price_Manager_Admin {
         </form>
         <hr>
         <h2><?php _e( 'Список услуг', 'wp-price-manager' ); ?></h2>
+        <?php if ( !$prefill_category ) : ?>
+        <form id="wppm-service-filter-form" method="post" action="">
+            <input type="text" id="wppm-filter-name" placeholder="<?php _e( 'Название', 'wp-price-manager' ); ?>">
+            <input type="text" id="wppm-filter-description" placeholder="<?php _e( 'Описание', 'wp-price-manager' ); ?>">
+            <input type="text" id="wppm-filter-price-group" placeholder="<?php _e( 'Группа цен', 'wp-price-manager' ); ?>">
+            <input type="text" id="wppm-filter-category" placeholder="<?php _e( 'Категория', 'wp-price-manager' ); ?>">
+            <button type="submit" class="button"><?php _e( 'Фильтровать', 'wp-price-manager' ); ?></button>
+        </form>
+        <?php endif; ?>
         <?php if ( isset($_GET['msg']) ) echo '<div class="updated"><p>' . esc_html($_GET['msg']) . '</p></div>'; ?>
         <?php if ( $prefill_category ) : ?>
             <p><?php _e( 'Перетащите строки для изменения порядка услуг (для выбранной категории)', 'wp-price-manager' ); ?></p>
@@ -226,7 +229,7 @@ class Price_Manager_Admin {
                     <th><?php _e( 'Действия', 'wp-price-manager' ); ?></th>
                 </tr>
             </thead>
-            <tbody <?php if ( $prefill_category ) echo 'id="wppm-services-sortable"'; ?>>
+            <tbody id="<?php echo $prefill_category ? 'wppm-services-sortable' : 'wppm-services-table'; ?>">
                 <?php if ( $services ) : ?>
                     <?php foreach ( $services as $srv ) : ?>
                         <tr data-id="<?php echo intval($srv['id']); ?>">
@@ -282,7 +285,7 @@ class Price_Manager_Admin {
         <div class="wrap">
             <h1><?php _e( 'Группа цен', 'wp-price-manager' ); ?></h1>
             <h2><?php _e( 'Добавить новую группу цен', 'wp-price-manager' ); ?></h2>
-            <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+            <form id="wppm-add-price-group-form" method="post" action="">
                 <input type="hidden" name="action" value="wppm_add_price_group">
                 <?php wp_nonce_field( 'wppm_price_group_nonce', 'wppm_price_group_nonce_field' ); ?>
                 <table class="form-table">

--- a/WP Price Manager/admin/js/admin.js
+++ b/WP Price Manager/admin/js/admin.js
@@ -135,4 +135,68 @@ jQuery(document).ready(function($) {
             $('#wppm-new-order').val(order.join(','));
         });
     }
+
+    // ============================
+    // Autocomplete for service form
+    // ============================
+    var catNames = [];
+    var pgNames  = [];
+
+    function loadAutocomplete() {
+        $.ajax({
+            url: wppm_ajax_obj.ajax_url,
+            method: 'POST',
+            data: {
+                action: 'wppm_ajax_action',
+                nonce: wppm_ajax_obj.nonce,
+                wppm_type: 'get_categories'
+            },
+            success: function(res){
+                if(res.success){
+                    catNames = $.map(res.categories, function(c){ return c.name; });
+                    $('#service_category').autocomplete({ source: catNames, minLength: 0 });
+                }
+            }
+        });
+
+        $.ajax({
+            url: wppm_ajax_obj.ajax_url,
+            method: 'POST',
+            data: {
+                action: 'wppm_ajax_action',
+                nonce: wppm_ajax_obj.nonce,
+                wppm_type: 'get_price_groups'
+            },
+            success: function(res){
+                if(res.success){
+                    var groups = res.get_price_groups || res.price_groups || res.priceGroups;
+                    pgNames = $.map(groups, function(pg){ return pg.name; });
+                    $('#price_group').autocomplete({ source: pgNames, minLength: 0 });
+                }
+            }
+        });
+    }
+
+    loadAutocomplete();
+
+    $(document).on('focus', '#service_category, #price_group', function(){
+        $(this).autocomplete('search', '');
+    });
+
+    $(document).on('submit', '#wppm-add-service-form, #wppm-edit-service-form', function(e){
+        var cat = $('#service_category').val();
+        var pg  = $('#price_group').val();
+        if(cat && $.inArray(cat, catNames) === -1){
+            if(!confirm('Создать новую категорию "' + cat + '"?')) {
+                e.preventDefault();
+                return false;
+            }
+        }
+        if(pg && $.inArray(pg, pgNames) === -1){
+            if(!confirm('Создать новую группу цен "' + pg + '"?')) {
+                e.preventDefault();
+                return false;
+            }
+        }
+    });
 });

--- a/WP Price Manager/admin/wppm-ajax-handler.php
+++ b/WP Price Manager/admin/wppm-ajax-handler.php
@@ -133,6 +133,167 @@ function wppm_handle_ajax() {
             $response = array( 'success' => true, 'get_price_groups' => $price_groups );
             break;
 
+        // --- Услуги ---
+        case 'add_service':
+            $srv_table = $wpdb->prefix . 'wppm_services';
+            $cat_table = $wpdb->prefix . 'wppm_categories';
+            $pg_table  = $wpdb->prefix . 'wppm_price_groups';
+
+            $name        = sanitize_text_field( $_POST['service_name'] );
+            $description = sanitize_textarea_field( $_POST['service_description'] );
+            $link        = esc_url_raw( $_POST['service_link'] );
+            $price       = floatval( $_POST['service_price'] );
+            $pg_name     = sanitize_text_field( $_POST['price_group'] );
+
+            if ( isset( $_POST['service_category_id'] ) && ! empty( $_POST['service_category_id'] ) ) {
+                $category_id = intval( $_POST['service_category_id'] );
+            } else {
+                $cat_name = sanitize_text_field( $_POST['service_category'] );
+                $existing_cat = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM $cat_table WHERE name = %s", $cat_name ) );
+                if ( $existing_cat ) {
+                    $category_id = $existing_cat->id;
+                } else {
+                    $wpdb->insert( $cat_table, array( 'name' => $cat_name, 'display_order' => 0 ), array( '%s', '%d' ) );
+                    $category_id = $wpdb->insert_id;
+                }
+            }
+
+            $existing_pg = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM $pg_table WHERE name = %s", $pg_name ) );
+            if ( $existing_pg ) {
+                $price_group_id = $existing_pg->id;
+            } else {
+                $wpdb->insert( $pg_table, array( 'name' => $pg_name, 'default_price' => $price ), array( '%s', '%f' ) );
+                $price_group_id = $wpdb->insert_id;
+            }
+
+            $result = $wpdb->insert( $srv_table, array(
+                'name'          => $name,
+                'description'   => $description,
+                'link'          => $link,
+                'price'         => $price,
+                'manual_price'  => 1,
+                'category_id'   => $category_id,
+                'price_group_id'=> $price_group_id,
+                'display_order' => 0,
+            ), array( '%s','%s','%s','%f','%d','%d','%d','%d' ) );
+
+            if ( $result ) {
+                $response = array( 'success' => true, 'message' => __( 'Услуга добавлена.', 'wp-price-manager' ) );
+            } else {
+                $response = array( 'success' => false, 'message' => __( 'Ошибка добавления услуги.', 'wp-price-manager' ) );
+            }
+            break;
+
+        case 'edit_service':
+            $srv_table = $wpdb->prefix . 'wppm_services';
+            $cat_table = $wpdb->prefix . 'wppm_categories';
+            $pg_table  = $wpdb->prefix . 'wppm_price_groups';
+
+            $id          = intval( $_POST['service_id'] );
+            $name        = sanitize_text_field( $_POST['service_name'] );
+            $description = sanitize_textarea_field( $_POST['service_description'] );
+            $link        = esc_url_raw( $_POST['service_link'] );
+            $price       = floatval( $_POST['service_price'] );
+            $pg_name     = sanitize_text_field( $_POST['price_group'] );
+            $cat_name    = sanitize_text_field( $_POST['service_category'] );
+
+            $existing_cat = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM $cat_table WHERE name = %s", $cat_name ) );
+            if ( $existing_cat ) {
+                $category_id = $existing_cat->id;
+            } else {
+                $wpdb->insert( $cat_table, array( 'name' => $cat_name, 'display_order' => 0 ), array( '%s', '%d' ) );
+                $category_id = $wpdb->insert_id;
+            }
+
+            $existing_pg = $wpdb->get_row( $wpdb->prepare( "SELECT id FROM $pg_table WHERE name = %s", $pg_name ) );
+            if ( $existing_pg ) {
+                $price_group_id = $existing_pg->id;
+            } else {
+                $wpdb->insert( $pg_table, array( 'name' => $pg_name, 'default_price' => $price ), array( '%s', '%f' ) );
+                $price_group_id = $wpdb->insert_id;
+            }
+
+            $result = $wpdb->update( $srv_table, array(
+                'name'          => $name,
+                'description'   => $description,
+                'link'          => $link,
+                'price'         => $price,
+                'manual_price'  => 1,
+                'category_id'   => $category_id,
+                'price_group_id'=> $price_group_id,
+            ), array( 'id' => $id ), array( '%s','%s','%s','%f','%d','%d','%d' ), array( '%d' ) );
+
+            if ( $result !== false ) {
+                $response = array( 'success' => true, 'message' => __( 'Услуга обновлена.', 'wp-price-manager' ) );
+            } else {
+                $response = array( 'success' => false, 'message' => __( 'Ошибка обновления услуги.', 'wp-price-manager' ) );
+            }
+            break;
+
+        // --- Поиск услуг ---
+        case 'search_services':
+            $srv_table = $wpdb->prefix . 'wppm_services';
+            $cat_table = $wpdb->prefix . 'wppm_categories';
+            $pg_table  = $wpdb->prefix . 'wppm_price_groups';
+            $name        = isset( $_POST['name'] ) ? sanitize_text_field( $_POST['name'] ) : '';
+            $description = isset( $_POST['description'] ) ? sanitize_text_field( $_POST['description'] ) : '';
+            $price_group = isset( $_POST['price_group'] ) ? sanitize_text_field( $_POST['price_group'] ) : '';
+            $category    = isset( $_POST['category'] ) ? sanitize_text_field( $_POST['category'] ) : '';
+            $sql = "SELECT s.*, c.name AS category_name, pg.name AS price_group_name FROM $srv_table s LEFT JOIN $cat_table c ON s.category_id = c.id LEFT JOIN $pg_table pg ON s.price_group_id = pg.id WHERE 1=1";
+            $params = array();
+            if ( $name ) {
+                $sql .= " AND s.name LIKE %s";
+                $params[] = '%' . $wpdb->esc_like( $name ) . '%';
+            }
+            if ( $description ) {
+                $sql .= " AND s.description LIKE %s";
+                $params[] = '%' . $wpdb->esc_like( $description ) . '%';
+            }
+            if ( $price_group ) {
+                $sql .= " AND pg.name LIKE %s";
+                $params[] = '%' . $wpdb->esc_like( $price_group ) . '%';
+            }
+            if ( $category ) {
+                $sql .= " AND c.name LIKE %s";
+                $params[] = '%' . $wpdb->esc_like( $category ) . '%';
+            }
+            $sql .= " ORDER BY s.display_order ASC";
+            $services = $wpdb->get_results( $wpdb->prepare( $sql, $params ), ARRAY_A );
+
+            ob_start();
+            if ( $services ) {
+                foreach ( $services as $srv ) {
+                    ?>
+                    <tr data-id="<?php echo intval( $srv['id'] ); ?>">
+                        <td><?php echo esc_html( $srv['id'] ); ?></td>
+                        <td><?php echo esc_html( $srv['name'] ); ?></td>
+                        <td><?php echo esc_html( $srv['description'] ); ?></td>
+                        <td>
+                            <?php if ( ! empty( $srv['link'] ) ) : ?>
+                                <a href="<?php echo esc_url( $srv['link'] ); ?>" target="_blank"><?php echo esc_html( $srv['link'] ); ?></a>
+                            <?php else : ?>
+                                <?php _e( 'Нет ссылки', 'wp-price-manager' ); ?>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo esc_html( $srv['price'] ); ?></td>
+                        <td><?php echo esc_html( $srv['category_name'] ); ?></td>
+                        <td><?php echo esc_html( $srv['price_group_name'] ); ?></td>
+                        <td>
+                            <a href="<?php echo admin_url( 'admin-post.php?action=wppm_edit_service_form&id=' . intval( $srv['id'] ) ); ?>"><?php _e( 'Редактировать', 'wp-price-manager' ); ?></a> |
+                            <a href="<?php echo admin_url( 'admin-post.php?action=wppm_delete_service&id=' . intval( $srv['id'] ) . '&_wpnonce=' . wp_create_nonce( 'wppm_delete_service_' . intval( $srv['id'] ) ) ); ?>" onclick="return confirm('<?php _e( 'Вы уверены?', 'wp-price-manager' ); ?>');"><?php _e( 'Удалить', 'wp-price-manager' ); ?></a>
+                        </td>
+                    </tr>
+                    <?php
+                }
+            } else {
+                ?>
+                <tr><td colspan="8"><?php _e( 'Услуги не найдены', 'wp-price-manager' ); ?></td></tr>
+                <?php
+            }
+            $html = ob_get_clean();
+            $response = array( 'success' => true, 'html' => $html );
+            break;
+
         default:
             $response = array( 'success' => false, 'message' => __( 'Неизвестный запрос.', 'wp-price-manager' ) );
             break;

--- a/WP Price Manager/admin/wppm-handler.php
+++ b/WP Price Manager/admin/wppm-handler.php
@@ -157,6 +157,66 @@ function wppm_add_service() {
 }
 add_action( 'admin_post_wppm_add_service', 'wppm_add_service' );
 
+// Форма быстрого добавления услуги из категории
+function wppm_add_service_form() {
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( __( 'Недостаточно прав', 'wp-price-manager' ) );
+    }
+    global $wpdb;
+    $cat_table = $wpdb->prefix . 'wppm_categories';
+
+    $prefill_category = isset( $_GET['category_id'] ) ? intval( $_GET['category_id'] ) : 0;
+    $category = null;
+    if ( $prefill_category ) {
+        $category = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $cat_table WHERE id = %d", $prefill_category ) );
+    }
+    ?>
+    <div class="wrap">
+        <h1><?php _e( 'Добавить услугу', 'wp-price-manager' ); ?></h1>
+        <form id="wppm-add-service-form" method="post" action="">
+            <input type="hidden" name="action" value="wppm_add_service">
+            <?php wp_nonce_field( 'wppm_service_nonce', 'wppm_service_nonce_field' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th><label for="service_name"><?php _e( 'Название услуги', 'wp-price-manager' ); ?></label></th>
+                    <td><input type="text" id="service_name" name="service_name" required></td>
+                </tr>
+                <tr>
+                    <th><label for="service_description"><?php _e( 'Описание', 'wp-price-manager' ); ?></label></th>
+                    <td><textarea id="service_description" name="service_description" required></textarea></td>
+                </tr>
+                <tr>
+                    <th><label for="service_link"><?php _e( 'Ссылка', 'wp-price-manager' ); ?></label></th>
+                    <td><input type="url" id="service_link" name="service_link" required></td>
+                </tr>
+                <tr>
+                    <th><label for="service_price"><?php _e( 'Цена (BYN)', 'wp-price-manager' ); ?></label></th>
+                    <td><input type="number" step="0.01" id="service_price" name="service_price" required></td>
+                </tr>
+                <tr>
+                    <th><label for="price_group"><?php _e( 'Группа цен', 'wp-price-manager' ); ?></label></th>
+                    <td><input type="text" id="price_group" name="price_group" required></td>
+                </tr>
+                <tr>
+                    <th><label for="service_category"><?php _e( 'Категория', 'wp-price-manager' ); ?></label></th>
+                    <td>
+                        <?php if ( $category ) : ?>
+                            <input type="hidden" name="service_category_id" value="<?php echo intval( $category->id ); ?>">
+                            <input type="text" value="<?php echo esc_attr( $category->name ); ?>" disabled>
+                        <?php else : ?>
+                            <input type="text" id="service_category" name="service_category" required>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+            </table>
+            <p class="submit"><input type="submit" class="button button-primary" value="<?php _e( 'Добавить услугу', 'wp-price-manager' ); ?>"></p>
+        </form>
+    </div>
+    <?php
+    exit;
+}
+add_action( 'admin_post_wppm_add_service_form', 'wppm_add_service_form' );
+
 // Форма редактирования услуги
 function wppm_edit_service_form() {
     if ( ! current_user_can( 'manage_options' ) ) {
@@ -175,7 +235,7 @@ function wppm_edit_service_form() {
     ?>
     <div class="wrap">
         <h1><?php _e( 'Редактировать услугу', 'wp-price-manager' ); ?></h1>
-        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+        <form id="wppm-edit-service-form" method="post" action="">
             <input type="hidden" name="action" value="wppm_edit_service">
             <input type="hidden" name="service_id" value="<?php echo intval($service['id']); ?>">
             <?php wp_nonce_field( 'wppm_service_nonce', 'wppm_service_nonce_field' ); ?>
@@ -330,7 +390,7 @@ function wppm_edit_price_group_form() {
     ?>
     <div class="wrap">
         <h1><?php _e( 'Редактировать группу цен', 'wp-price-manager' ); ?></h1>
-        <form method="post" action="<?php echo admin_url('admin-post.php'); ?>">
+        <form id="wppm-edit-price-group-form" method="post" action="">
             <input type="hidden" name="action" value="wppm_edit_price_group">
             <input type="hidden" name="price_group_id" value="<?php echo intval($group['id']); ?>">
             <?php wp_nonce_field( 'wppm_price_group_nonce', 'wppm_price_group_nonce_field' ); ?>

--- a/WP Price Manager/elementor/elementor-widget-price-list.php
+++ b/WP Price Manager/elementor/elementor-widget-price-list.php
@@ -150,28 +150,51 @@ class Elementor_Price_List_Widget extends Widget_Base {
 			]
 		);
 
-		$this->add_control(
-			'header_alignment',
-			[
-				'label'   => __( 'Выравнивание заголовка', 'wp-price-manager' ),
-				'type'    => Controls_Manager::CHOOSE,
-				'options' => [
-					'left'   => [
-						'title' => __( 'Left', 'wp-price-manager' ),
-						'icon'  => 'eicon-text-align-left',
-					],
-					'center' => [
-						'title' => __( 'Center', 'wp-price-manager' ),
-						'icon'  => 'eicon-text-align-center',
-					],
-					'right'  => [
-						'title' => __( 'Right', 'wp-price-manager' ),
-						'icon'  => 'eicon-text-align-right',
-					],
-				],
-				'default' => 'left',
-			]
-		);
+                $this->add_control(
+                        'header_alignment',
+                        [
+                                'label'   => __( 'Выравнивание заголовка', 'wp-price-manager' ),
+                                'type'    => Controls_Manager::CHOOSE,
+                                'options' => [
+                                        'left'   => [
+                                                'title' => __( 'Left', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-left',
+                                        ],
+                                        'center' => [
+                                                'title' => __( 'Center', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-center',
+                                        ],
+                                        'right'  => [
+                                                'title' => __( 'Right', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-right',
+                                        ],
+                                ],
+                                'default' => 'left',
+                        ]
+                );
+
+                $this->add_control(
+                        'row_alignment',
+                        [
+                                'label'   => __( 'Выравнивание строк', 'wp-price-manager' ),
+                                'type'    => Controls_Manager::CHOOSE,
+                                'options' => [
+                                        'left'   => [
+                                                'title' => __( 'Left', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-left',
+                                        ],
+                                        'center' => [
+                                                'title' => __( 'Center', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-center',
+                                        ],
+                                        'right'  => [
+                                                'title' => __( 'Right', 'wp-price-manager' ),
+                                                'icon'  => 'eicon-text-align-right',
+                                        ],
+                                ],
+                                'default' => 'left',
+                        ]
+                );
 
 		$this->end_controls_section();
 	}
@@ -223,13 +246,13 @@ class Elementor_Price_List_Widget extends Widget_Base {
 						<th><?php _e( 'Цена', 'wp-price-manager' ); ?></th>
 					</tr>
 				</thead>
-				<tbody>
-					<?php if ( ! empty( $services ) ) : ?>
-						<?php foreach ( $services as $index => $service ) : ?>
-							<?php
-							$display_price = ( $service['manual_price'] ? $service['price'] : ( $service['default_price'] ? $service['default_price'] : $service['price'] ) );
-							?>
-							<tr style="background: <?php echo $index % 2 === 0 ? esc_attr( $settings['even_row_bg_color'] ) : esc_attr( $settings['odd_row_bg_color'] ); ?>; height: <?php echo esc_attr( $settings['row_height'] ); ?>;">
+                                <tbody>
+                                        <?php if ( ! empty( $services ) ) : ?>
+                                                <?php foreach ( $services as $index => $service ) : ?>
+                                                        <?php
+                                                        $display_price = ( $service['manual_price'] ? $service['price'] : ( $service['default_price'] ? $service['default_price'] : $service['price'] ) );
+                                                        ?>
+                                                        <tr style="background: <?php echo $index % 2 === 0 ? esc_attr( $settings['even_row_bg_color'] ) : esc_attr( $settings['odd_row_bg_color'] ); ?>; height: <?php echo esc_attr( $settings['row_height'] ); ?>; text-align: <?php echo esc_attr( $settings['row_alignment'] ); ?>;">
 								<td>
 									<a href="<?php echo esc_url( $service['link'] ); ?>" target="_blank">
 										<?php echo esc_html( $service['name'] ); ?>

--- a/WP Price Manager/js/admin.js
+++ b/WP Price Manager/js/admin.js
@@ -132,7 +132,119 @@ jQuery(document).ready(function($) {
                     order.push(id);
                 }
             });
-            $('#wppm-new-order').val(order.join(','));
+        $('#wppm-new-order').val(order.join(','));
         });
     }
+
+
+    function submitServiceForm(type, extra){
+        var cat = $('#service_category').val();
+        var pg  = $('#price_group').val();
+        var data = {
+            action: 'wppm_ajax_action',
+            nonce: wppm_ajax_obj.nonce,
+            wppm_type: type,
+            service_name: $('#service_name').val(),
+            service_description: $('#service_description').val(),
+            service_link: $('#service_link').val(),
+            service_price: $('#service_price').val(),
+            price_group: pg,
+            service_category: cat,
+            service_category_id: $('input[name="service_category_id"]').val() || ''
+        };
+        $.extend(data, extra || {});
+        $.post(wppm_ajax_obj.ajax_url, data, function(res){
+            alert(res.message);
+            if(res.success){
+                location.reload();
+            }
+        });
+    }
+
+    $(document).on('submit', '#wppm-add-service-form', function(e){
+        if (e.isDefaultPrevented()) return;
+        e.preventDefault();
+        submitServiceForm('add_service');
+    });
+
+    $(document).on('submit', '#wppm-edit-service-form', function(e){
+        if (e.isDefaultPrevented()) return;
+        e.preventDefault();
+        submitServiceForm('edit_service', {service_id: $('input[name="service_id"]').val()});
+    });
+
+    // ============================
+    // Confirm and submit price group forms via AJAX
+    // ============================
+    function sendPriceGroup(data){
+        $.post(wppm_ajax_obj.ajax_url, data, function(res){
+            if(res.need_confirm){
+                $('<div>' + res.message + '</div>').dialog({
+                    modal:true,
+                    title:wppm_ajax_obj.confirm_price_change_title,
+                    buttons:{
+                        'Подтвердить': function(){ $(this).dialog('close'); data.confirm=1; sendPriceGroup(data); },
+                        'Отмена': function(){ $(this).dialog('close'); }
+                    }
+                });
+            } else {
+                alert(res.message);
+                if(res.success){ location.reload(); }
+            }
+        });
+    }
+
+    $(document).on('submit', '#wppm-add-price-group-form', function(e){
+        e.preventDefault();
+        var data = {
+            action:'wppm_ajax_action',
+            nonce: wppm_ajax_obj.nonce,
+            wppm_type:'add_price_group',
+            price_group_name: $('#price_group_name').val(),
+            default_price: $('#default_price').val()
+        };
+        sendPriceGroup(data);
+    });
+
+    if($('#wppm-edit-price-group-form').length){
+        $('#wppm-edit-price-group-form').on('submit', function(e){
+            e.preventDefault();
+            var data = {
+                action:'wppm_ajax_action',
+                nonce: wppm_ajax_obj.nonce,
+                wppm_type:'edit_price_group',
+                id: $('input[name="price_group_id"]').val(),
+                price_group_name: $('#price_group_name').val(),
+                default_price: $('#default_price').val()
+            };
+            sendPriceGroup(data);
+        });
+    }
+
+    // ============================
+    // Фильтрация услуг через AJAX
+    // ============================
+    $('#wppm-service-filter-form').on('submit', function(e){
+        e.preventDefault();
+        var data = {
+            action: 'wppm_ajax_action',
+            nonce: wppm_ajax_obj.nonce,
+            wppm_type: 'search_services',
+            name: $('#wppm-filter-name').val(),
+            description: $('#wppm-filter-description').val(),
+            price_group: $('#wppm-filter-price-group').val(),
+            category: $('#wppm-filter-category').val()
+        };
+        $.post(wppm_ajax_obj.ajax_url, data, function(res){
+            if(res.success){
+                var tbody = $('#wppm-services-table');
+                if(!tbody.length){
+                    tbody = $('#wppm-services-sortable');
+                }
+                tbody.html(res.html);
+            } else {
+                alert(res.message);
+            }
+        });
+    });
 });

--- a/WP Price Manager/wp-price-manager.php
+++ b/WP Price Manager/wp-price-manager.php
@@ -65,6 +65,7 @@ register_activation_hook( __FILE__, 'wppm_install' );
 if ( is_admin() ) {
     require_once WPPM_PLUGIN_DIR . 'admin/class-price-manager-admin.php';
     require_once WPPM_PLUGIN_DIR . 'admin/wppm-handler.php';
+    require_once WPPM_PLUGIN_DIR . 'admin/wppm-ajax-handler.php';
 }
 
 // Подключаем виджет для Elementor (если плагин Elementor активен)
@@ -79,11 +80,15 @@ function wppm_check_elementor() {
 function wppm_admin_enqueue_scripts( $hook ) {
     // Для страниц плагина можно проверять, содержит ли $hook нужное значение.
     if ( strpos( $hook, 'price-manager' ) !== false ) {
-        wp_enqueue_script( 'wppm-admin-js', WPPM_PLUGIN_URL . 'js/admin.js', array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-autocomplete' ), '1.0', true );
+        wp_enqueue_script( 'wppm-autocomplete-js', WPPM_PLUGIN_URL . 'admin/js/admin.js', array( 'jquery', 'jquery-ui-autocomplete' ), '1.0', true );
+        wp_enqueue_script( 'wppm-admin-js', WPPM_PLUGIN_URL . 'js/admin.js', array( 'wppm-autocomplete-js', 'jquery', 'jquery-ui-sortable', 'jquery-ui-dialog' ), '1.0', true );
         wp_enqueue_style( 'wppm-admin-css', WPPM_PLUGIN_URL . 'css/admin.css' );
+        wp_enqueue_style( 'wp-jquery-ui-dialog' );
         wp_localize_script( 'wppm-admin-js', 'wppm_ajax_obj', array(
             'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'nonce'    => wp_create_nonce( 'wppm_nonce' )
+            'nonce'    => wp_create_nonce( 'wppm_nonce' ),
+            'confirm_price_change_title'   => __( 'Подтверждение', 'wp-price-manager' ),
+            'confirm_price_change_message' => __( 'Изменение цены повлияет на все связанные услуги. Подтвердить?', 'wp-price-manager' )
         ) );
     }
 }


### PR DESCRIPTION
## Summary
- enqueue the dedicated `admin/js/admin.js` script for form autocomplete
- remove duplicate autocomplete logic from the main admin script
- guard AJAX form handlers when confirmation dialogs cancel submission

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68599eb1d238832fa7ef44f17a4f3254